### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,9 @@
 
 name: .NET Core Desktop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -40,6 +40,9 @@ name: .NET Core Desktop
 
 permissions:
   contents: read
+  actions: read
+  checks: write
+  packages: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/derskythe/DbHelper/security/code-scanning/1](https://github.com/derskythe/DbHelper/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add the following at the top level of the workflow (just after the `name:` and before the `on:` block):  
```yaml
permissions:
  contents: read
```
This ensures that all jobs in the workflow will only have read access to repository contents, which is sufficient for checking out code and uploading artifacts. No changes to the jobs themselves are necessary. Only a single edit to the YAML file is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
